### PR TITLE
Type annotation support & changed `identifier` to `name`

### DIFF
--- a/examples/example.json
+++ b/examples/example.json
@@ -1,12 +1,12 @@
 [
   {
-    "identifier": "thermal-paste",
+    "name": "thermal-paste",
     "arguments": [
       "NT-H1"
     ],
     "children": [
       {
-        "identifier": "description",
+        "name": "description",
         "arguments": [
           "it tastes nice:)"
         ]


### PR DESCRIPTION
After rediscovering the [NixOS `formats.kdl` PR](https://github.com/NixOS/nixpkgs/pull/295211), I finally came around to implementing type annotation support [as requested in one of the comments](https://github.com/NixOS/nixpkgs/pull/295211#issuecomment-1997189500).

This also changes the `identifier` field of nodes to `name`, as this property is usually referred to as "the name of the node" in the KDL docs.

If you're fine with these changes and decide to merge this, it would be nice if you could tag a new version again.
The relevant changes to the NixOS PR (besides updating the `json2kdl` package to the new version) can be viewed in [this temporary PR](https://github.com/feathecutie/nixpkgs/pull/1) and will be merged into the main NixOS PR once this gets merged.